### PR TITLE
Search field edit

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -158,7 +158,6 @@ class SearchForm extends React.Component {
 
             if(this.state.fields.length===0){
                 this.addFilterNamed([
-                    "Country",
                     "N50",
                     "Completeness",
                     "Contamination"


### PR DESCRIPTION
Remove country from default search field options to get rid of no entries problem due to empty search field. Now default search button gives all the entries.